### PR TITLE
[Feat] 대화학습 백엔드 연결

### DIFF
--- a/NurVo_Frontend/App.tsx
+++ b/NurVo_Frontend/App.tsx
@@ -23,6 +23,7 @@ import Bookmark from './src/pages/Bookmark';
 import StudyPage from './src/pages/StudyPage';
 import MemberDetails from './src/pages/MemberDetails';
 import SetUserGoal from './src/pages/SetUserGoal';
+import { HomeStackParamList } from './src/utilities/NavigationTypes';
 
 const Tab = createBottomTabNavigator();
 function BottomTabs() {
@@ -55,7 +56,7 @@ function BottomTabs() {
 
 
 
-const HomeStack = createNativeStackNavigator();
+const HomeStack = createNativeStackNavigator<HomeStackParamList>();
 const HomeStackScreen = () => {
   return (
     <HomeStack.Navigator
@@ -65,7 +66,7 @@ const HomeStackScreen = () => {
       }}
     >
       <HomeStack.Screen name="HomeScreen" component={Home} options={{ headerShown: false }} />
-      <HomeStack.Screen name="LessonsList" component={LessonsList} />
+      <HomeStack.Screen name="LessonList" component={LessonsList} />
       <HomeStack.Screen name="LessonFirstScreen" component={LessonFirst} />
       <HomeStack.Screen name="LessonSecondScreen" component={LessonSecond} />
       <HomeStack.Screen name="LessonThirdScreen" component={LessonThird} />

--- a/NurVo_Frontend/App.tsx
+++ b/NurVo_Frontend/App.tsx
@@ -6,7 +6,6 @@
  */
 
 import React from 'react';
-import { StyleSheet, Text, View, SafeAreaView } from 'react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';

--- a/NurVo_Frontend/package-lock.json
+++ b/NurVo_Frontend/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.4.0",
         "react": "18.2.0",
         "react-native": "^0.72.3",
+        "react-native-animatable": "^1.3.3",
         "react-native-circular-progress": "^1.3.9",
         "react-native-dotenv": "^3.4.9",
         "react-native-fs": "^2.20.0",
@@ -13187,11 +13188,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/property-expr": {
       "version": "2.0.5",

--- a/NurVo_Frontend/package.json
+++ b/NurVo_Frontend/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.4.0",
     "react": "18.2.0",
     "react-native": "^0.72.3",
+    "react-native-animatable": "^1.3.3",
     "react-native-circular-progress": "^1.3.9",
     "react-native-dotenv": "^3.4.9",
     "react-native-fs": "^2.20.0",

--- a/NurVo_Frontend/src/@types/env.d.ts
+++ b/NurVo_Frontend/src/@types/env.d.ts
@@ -3,4 +3,5 @@ declare module '@env' {
     export const SPEECH_KEY_ANDROID: string;
     export const SPEECH_KEY: string;
     export const RN_HOST_URL: string;
+    export const TEST_TOKEN: string;
 }

--- a/NurVo_Frontend/src/@types/env.d.ts
+++ b/NurVo_Frontend/src/@types/env.d.ts
@@ -2,4 +2,5 @@ declare module '@env' {
     export const SPEECH_KEY_IOS: string;
     export const SPEECH_KEY_ANDROID: string;
     export const SPEECH_KEY: string;
+    export const RN_HOST_URL: string;
 }

--- a/NurVo_Frontend/src/@types/env.d.ts
+++ b/NurVo_Frontend/src/@types/env.d.ts
@@ -4,4 +4,5 @@ declare module '@env' {
     export const SPEECH_KEY: string;
     export const RN_HOST_URL: string;
     export const TEST_TOKEN: string;
+    export const TEST_USERID: string;
 }

--- a/NurVo_Frontend/src/components/ChatBubble.tsx
+++ b/NurVo_Frontend/src/components/ChatBubble.tsx
@@ -2,7 +2,7 @@ import { Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from "r
 import { useEffect, useState } from "react";
 import Ionicons from 'react-native-vector-icons/Ionicons';
 
-import { Body011, Body012, Body013, Subtext013 } from "../utilities/Fonts";
+import { Body011, Body012, Body013, Body023, Subtext013 } from "../utilities/Fonts";
 import { layoutStyles, screenWidth } from "../utilities/Layout";
 import Colors from "../utilities/Color";
 import { speech } from "../utilities/TextToSpeech";
@@ -50,38 +50,38 @@ export default function ChatBubble({ index, item, isBookmarked, isSpeaking, spea
   const handleSpeak = () => {
     if (!(speakingList.some(value => value)) && onIsClickSpeakChange) {
       onIsClickSpeakChange(true);
-      speech(item.dialogue, item.id, item.speaker === 'Nurse', () => { onIsClickSpeakChange(false) });
+      speech(item.dialogue, item.id, item.speaker.trim().toLowerCase() === 'nurse', () => { onIsClickSpeakChange(false) });
     }
   }
   return (
     <View key={index} style={[
-      item.speaker === 'Nurse' ? bubbleStyles.messageContainerRight : bubbleStyles.messageContainerLeft
+      item.speaker.trim().toLowerCase() === 'nurse' ? bubbleStyles.messageContainerRight : bubbleStyles.messageContainerLeft
     ]}>
       <View style={[
         bubbleStyles.bubble,
-        item.speaker === 'Nurse' ? bubbleStyles.bubbleRight : bubbleStyles.bubbleLeft
+        item.speaker.trim().toLowerCase() === 'nurse' ? bubbleStyles.bubbleRight : bubbleStyles.bubbleLeft
       ]}>
-        {item.speaker === 'Nurse' ?
+        {item.speaker.trim().toLowerCase() === 'nurse' ?
           <Body012 text={item.dialogue} color={Colors.WHITE} /> :
           <Body012 text={item.dialogue} color={Colors.BLACK} />}
-        {isShowTranslation && <Body013 text={item.korean} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} />}
+        {isShowTranslation && <Body013 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />}
         <View style={[
           layoutStyles.HStackContainer,
           {
             flexWrap: 'wrap',
             justifyContent: 'space-evenly',
-            alignSelf: item.speaker === 'Nurse' ? 'flex-start' : 'flex-end',
+            alignSelf: item.speaker.trim().toLowerCase() === 'Nurse' ? 'flex-start' : 'flex-end',
             marginTop: 16,
           }
         ]}>
-          {item.speaker === 'Nurse' && <TouchableOpacity onPress={handleBookmark}>
-            <Ionicons name={isBookmark ? "bookmark" : "bookmark-outline"} size={20} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} />
+          {item.speaker.trim().toLowerCase() === 'nurse' && <TouchableOpacity onPress={handleBookmark}>
+            <Ionicons name={isBookmark ? "bookmark" : "bookmark-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
           </TouchableOpacity>}
           <TouchableOpacity onPress={handleBook}>
-            <Ionicons name={isShowTranslation ? "book" : "book-outline"} size={20} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
+            <Ionicons name={isShowTranslation ? "book" : "book-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
           </TouchableOpacity>
           <TouchableOpacity onPress={handleSpeak}>
-            <Ionicons name={isSpeaking ? "volume-high" : "volume-high-outline"} size={20} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} />
+            <Ionicons name={isSpeaking ? "volume-high" : "volume-high-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
           </TouchableOpacity>
         </View>
       </View>
@@ -102,7 +102,7 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
   const handleSpeak = () => {
     if (!(speakingList.some(value => value)) && onIsClickSpeakChange) {
       onIsClickSpeakChange(true);
-      speech(item.dialogue, item.id, item.speaker === 'Nurse', () => { onIsClickSpeakChange(false) });
+      speech(item.dialogue, item.id, item.speaker.trim().toLowerCase() === 'nurse', () => { onIsClickSpeakChange(false) });
     }
   }
 
@@ -110,12 +110,12 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
 
   return (
     <View key={index} style={[
-      item.speaker === 'Nurse' ? bubbleStyles.messageContainerRight : bubbleStyles.messageContainerLeft
+      item.speaker.trim().toLowerCase() === 'nurse' ? bubbleStyles.messageContainerRight : bubbleStyles.messageContainerLeft
     ]}>
       <View style={[
         bubbleStyles.bubble,
         inputBubbleStyles.container,
-        item.speaker === 'Nurse' ? bubbleStyles.bubbleRight : bubbleStyles.bubbleLeft,
+        item.speaker.trim().toLowerCase() === 'nurse' ? bubbleStyles.bubbleRight : bubbleStyles.bubbleLeft,
         { flexDirection: 'row', flexWrap: 'wrap' }
       ]}>
         <View style={[layoutStyles.VStackContainer]}>
@@ -125,7 +125,7 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
                 <Body012
                   key={index}
                   text={segment}
-                  color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK}
+                  color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK}
                 />
               );
             } else {
@@ -148,24 +148,24 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
             }
           })}
         </View>
-        {isShowTranslation && <Subtext013 text={item.korean} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} />}
+        {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />}
         <View style={[
           layoutStyles.HStackContainer,
           {
             width: '100%',
             flexWrap: 'wrap',
-            justifyContent: item.speaker === 'Nurse' ? 'flex-start' : 'flex-end',
+            justifyContent: item.speaker.trim().toLowerCase() === 'nurse' ? 'flex-start' : 'flex-end',
             marginTop: 16,
           }
         ]}>
-          {item.speaker === 'Nurse' && <TouchableOpacity onPress={handleBookmark}>
-            <Ionicons name={isBookmark ? "bookmark" : "bookmark-outline"} size={20} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} />
+          {item.speaker.trim().toLowerCase() === 'nurse' && <TouchableOpacity onPress={handleBookmark}>
+            <Ionicons name={isBookmark ? "bookmark" : "bookmark-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
           </TouchableOpacity>}
           <TouchableOpacity onPress={handleBook}>
-            <Ionicons name={isShowTranslation ? "book" : "book-outline"} size={20} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
+            <Ionicons name={isShowTranslation ? "book" : "book-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
           </TouchableOpacity>
-          {!(isLastItem && item.speaker === 'Nurse') && <TouchableOpacity onPress={handleSpeak}>
-            <Ionicons name={isSpeaking ? "volume-high" : "volume-high-outline"} size={20} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} />
+          {!(isLastItem && item.speaker.trim().toLowerCase() === 'nurse') && <TouchableOpacity onPress={handleSpeak}>
+            <Ionicons name={isSpeaking ? "volume-high" : "volume-high-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
           </TouchableOpacity>}
         </View>
       </View>
@@ -195,22 +195,22 @@ export function ChatBubbleInputAll({ index, item, chapterId, isBookmarked, onEnt
   const handleSpeak = () => {
     if (!(speakingList.some(value => value)) && onIsClickSpeakChange) {
       onIsClickSpeakChange(true);
-      speech(item.second_step ? item.second_step : item.dialogue, item.id, item.speaker === 'Nurse', () => { onIsClickSpeakChange(false) });
+      speech(item.second_step ? item.second_step : item.dialogue, item.id, item.speaker.trim().toLowerCase() === 'nurse', () => { onIsClickSpeakChange(false) });
     }
   }
 
   return (
     <View key={item.id} style={[
-      item.speaker === 'Nurse' ? bubbleStyles.messageContainerRight : bubbleStyles.messageContainerLeft
+      item.speaker.trim().toLowerCase() === 'nurse' ? bubbleStyles.messageContainerRight : bubbleStyles.messageContainerLeft
     ]}>
       <View style={[
         bubbleStyles.bubble,
         inputBubbleStyles.container,
-        item.speaker === 'Nurse' ? bubbleStyles.bubbleRight : bubbleStyles.bubbleLeft,
+        item.speaker.trim().toLowerCase() === 'nurse' ? bubbleStyles.bubbleRight : bubbleStyles.bubbleLeft,
         { flexDirection: 'row', flexWrap: 'wrap' }
       ]}>
         <View style={[layoutStyles.VStackContainer, { width: '100%' }]}>
-          {item.speaker === 'Nurse' ?
+          {item.speaker.trim().toLowerCase() === 'nurse' ?
             (isLastItem ?
               <TextInput
                 style={[inputBubbleStyles.input, { color: Colors.BLACK, marginVertical: 4 }]}
@@ -223,24 +223,24 @@ export function ChatBubbleInputAll({ index, item, chapterId, isBookmarked, onEnt
               /> :
               inputValues && checkInputWord(index, inputValues[item.id], item.second_step)
             ) :
-            (<Body012 key={index} text={item.dialogue} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} />)}
-          {isShowTranslation && <Subtext013 text={item.korean} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} />}
+            (<Body012 key={index} text={item.dialogue} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />)}
+          {isShowTranslation && <Subtext013 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />}
           <View style={[
             layoutStyles.HStackContainer,
             {
               flexWrap: 'wrap',
-              justifyContent: item.speaker === 'Nurse' ? 'flex-start' : 'flex-end',
+              justifyContent: item.speaker.trim().toLowerCase() === 'nurse' ? 'flex-start' : 'flex-end',
               marginTop: 16,
             }
           ]}>
-            {item.speaker === 'Nurse' && <TouchableOpacity onPress={handleBookmark}>
-              <Ionicons name={isBookmark ? "bookmark" : "bookmark-outline"} size={20} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} />
+            {item.speaker.trim().toLowerCase() === 'nurse' && <TouchableOpacity onPress={handleBookmark}>
+              <Ionicons name={isBookmark ? "bookmark" : "bookmark-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
             </TouchableOpacity>}
             <TouchableOpacity onPress={handleBook}>
-              <Ionicons name={isShowTranslation ? "book" : "book-outline"} size={20} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
+              <Ionicons name={isShowTranslation ? "book" : "book-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
             </TouchableOpacity>
-            {!(isLastItem && item.speaker === 'Nurse') && <TouchableOpacity onPress={handleSpeak}>
-              <Ionicons name={isSpeaking ? "volume-high" : "volume-high-outline"} size={20} color={item.speaker === 'Nurse' ? Colors.WHITE : Colors.BLACK} />
+            {!(isLastItem && item.speaker.trim().toLowerCase() === 'nurse') && <TouchableOpacity onPress={handleSpeak}>
+              <Ionicons name={isSpeaking ? "volume-high" : "volume-high-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
             </TouchableOpacity>}
           </View>
         </View>

--- a/NurVo_Frontend/src/components/ChatBubble.tsx
+++ b/NurVo_Frontend/src/components/ChatBubble.tsx
@@ -72,7 +72,7 @@ export default function ChatBubble({ index, item, isBookmarked, isSpeaking, spea
         item.speaker.trim().toLowerCase() === 'nurse' ? bubbleStyles.bubbleRight : bubbleStyles.bubbleLeft
       ]}>
         <Body012 text={item.dialogue} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
-        {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={bubbleStyles.translation}/>}
+        {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.GRAY09 : Colors.GRAY03} style={bubbleStyles.translation}/>}
         <View style={[
           layoutStyles.HStackContainer,
           {
@@ -163,7 +163,7 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
             }
           })}
         </View>
-        {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={bubbleStyles.translation}/>}
+        {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.GRAY09 : Colors.GRAY03} style={bubbleStyles.translation}/>}
         <View style={[
           layoutStyles.HStackContainer,
           {
@@ -239,7 +239,7 @@ export function ChatBubbleInputAll({ index, item, isBookmarked, onEnterValue, on
               inputValues && checkInputWord(index, inputValues[item.id], item.second_step)
             ) :
             (<Body012 key={index} text={item.dialogue} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />)}
-          {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={bubbleStyles.translation}/>}
+          {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.GRAY09 : Colors.GRAY03} style={bubbleStyles.translation}/>}
           <View style={[
             layoutStyles.HStackContainer,
             {

--- a/NurVo_Frontend/src/components/ChatBubble.tsx
+++ b/NurVo_Frontend/src/components/ChatBubble.tsx
@@ -78,7 +78,7 @@ export default function ChatBubble({ index, item, isBookmarked, isSpeaking, spea
           {
             flexWrap: 'wrap',
             justifyContent: 'space-evenly',
-            alignSelf: item.speaker.trim().toLowerCase() === 'Nurse' ? 'flex-start' : 'flex-end',
+            alignSelf: item.speaker.trim().toLowerCase() === 'nurse' ? 'flex-start' : 'flex-end',
             marginTop: 16,
           }
         ]}>

--- a/NurVo_Frontend/src/components/ChatBubble.tsx
+++ b/NurVo_Frontend/src/components/ChatBubble.tsx
@@ -2,7 +2,7 @@ import { Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from "r
 import { useEffect, useState } from "react";
 import Ionicons from 'react-native-vector-icons/Ionicons';
 
-import { Body011, Body012, Body013, Body023, Subtext013 } from "../utilities/Fonts";
+import { Body011, Body012, Body023 } from "../utilities/Fonts";
 import { layoutStyles, screenWidth } from "../utilities/Layout";
 import Colors from "../utilities/Color";
 import { speech } from "../utilities/TextToSpeech";
@@ -34,6 +34,9 @@ interface ChatBubbleProps {
 }
 
 const userId = TEST_USERID;
+const icon_speak = "volume-high";
+const icon_translation = "language";
+const icon_bookmark = "bookmark";
 
 export default function ChatBubble({ index, item, isBookmarked, isSpeaking, speakingList, onIsClickSpeakChange }: ChatBubbleProps) {
   useEffect(() => {
@@ -68,10 +71,8 @@ export default function ChatBubble({ index, item, isBookmarked, isSpeaking, spea
         bubbleStyles.bubble,
         item.speaker.trim().toLowerCase() === 'nurse' ? bubbleStyles.bubbleRight : bubbleStyles.bubbleLeft
       ]}>
-        {item.speaker.trim().toLowerCase() === 'nurse' ?
-          <Body012 text={item.dialogue} color={Colors.WHITE} /> :
-          <Body012 text={item.dialogue} color={Colors.BLACK} />}
-        {isShowTranslation && <Body013 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />}
+        <Body012 text={item.dialogue} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
+        {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={bubbleStyles.translation}/>}
         <View style={[
           layoutStyles.HStackContainer,
           {
@@ -82,13 +83,13 @@ export default function ChatBubble({ index, item, isBookmarked, isSpeaking, spea
           }
         ]}>
           {item.speaker.trim().toLowerCase() === 'nurse' && <TouchableOpacity onPress={handleBookmark}>
-            <Ionicons name={isBookmark ? "bookmark" : "bookmark-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
+            <Ionicons name={isBookmark ? icon_bookmark : `${icon_bookmark}-outline`} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
           </TouchableOpacity>}
           <TouchableOpacity onPress={handleBook}>
-            <Ionicons name={isShowTranslation ? "book" : "book-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
+            <Ionicons name={isShowTranslation ? icon_translation : `${icon_translation}-outline`} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
           </TouchableOpacity>
           <TouchableOpacity onPress={handleSpeak}>
-            <Ionicons name={isSpeaking ? "volume-high" : "volume-high-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
+            <Ionicons name={isSpeaking ?  icon_speak : `${icon_speak}-outline`} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
           </TouchableOpacity>
         </View>
       </View>
@@ -162,7 +163,7 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
             }
           })}
         </View>
-        {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />}
+        {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={bubbleStyles.translation}/>}
         <View style={[
           layoutStyles.HStackContainer,
           {
@@ -173,13 +174,13 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
           }
         ]}>
           {item.speaker.trim().toLowerCase() === 'nurse' && <TouchableOpacity onPress={handleBookmark}>
-            <Ionicons name={isBookmark ? "bookmark" : "bookmark-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
+            <Ionicons name={isBookmark ? icon_bookmark : `${icon_bookmark}-outline`} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
           </TouchableOpacity>}
           <TouchableOpacity onPress={handleBook}>
-            <Ionicons name={isShowTranslation ? "book" : "book-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
+            <Ionicons name={isShowTranslation ? icon_translation : `${icon_translation}-outline`} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
           </TouchableOpacity>
           {!(isLastItem && item.speaker.trim().toLowerCase() === 'nurse') && <TouchableOpacity onPress={handleSpeak}>
-            <Ionicons name={isSpeaking ? "volume-high" : "volume-high-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
+            <Ionicons name={isSpeaking ? icon_speak : `${icon_speak}-outline`} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
           </TouchableOpacity>}
         </View>
       </View>
@@ -238,7 +239,7 @@ export function ChatBubbleInputAll({ index, item, isBookmarked, onEnterValue, on
               inputValues && checkInputWord(index, inputValues[item.id], item.second_step)
             ) :
             (<Body012 key={index} text={item.dialogue} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />)}
-          {isShowTranslation && <Subtext013 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />}
+          {isShowTranslation && <Body023 text={item.korean} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={bubbleStyles.translation}/>}
           <View style={[
             layoutStyles.HStackContainer,
             {
@@ -248,13 +249,13 @@ export function ChatBubbleInputAll({ index, item, isBookmarked, onEnterValue, on
             }
           ]}>
             {item.speaker.trim().toLowerCase() === 'nurse' && <TouchableOpacity onPress={handleBookmark}>
-              <Ionicons name={isBookmark ? "bookmark" : "bookmark-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
+              <Ionicons name={isBookmark ? icon_bookmark : `${icon_bookmark}-outline`} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
             </TouchableOpacity>}
             <TouchableOpacity onPress={handleBook}>
-              <Ionicons name={isShowTranslation ? "book" : "book-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
+              <Ionicons name={isShowTranslation ? icon_translation : `${icon_translation}-outline`} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} style={{ marginHorizontal: 16 }} />
             </TouchableOpacity>
             {!(isLastItem && item.speaker.trim().toLowerCase() === 'nurse') && <TouchableOpacity onPress={handleSpeak}>
-              <Ionicons name={isSpeaking ? "volume-high" : "volume-high-outline"} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
+              <Ionicons name={isSpeaking ? icon_speak : `${icon_speak}-outline`} size={20} color={item.speaker.trim().toLowerCase() === 'nurse' ? Colors.WHITE : Colors.BLACK} />
             </TouchableOpacity>}
           </View>
         </View>
@@ -326,6 +327,9 @@ const bubbleStyles = StyleSheet.create({
     backgroundColor: Colors.WHITE,
     borderTopLeftRadius: 0,
   },
+  translation: {
+    marginTop: 8,
+  }
 });
 
 const inputBubbleStyles = StyleSheet.create({

--- a/NurVo_Frontend/src/components/ChatBubble.tsx
+++ b/NurVo_Frontend/src/components/ChatBubble.tsx
@@ -6,7 +6,8 @@ import { Body011, Body012, Body013, Body023, Subtext013 } from "../utilities/Fon
 import { layoutStyles, screenWidth } from "../utilities/Layout";
 import Colors from "../utilities/Color";
 import { speech } from "../utilities/TextToSpeech";
-import { addSentenceBookmark } from "../utilities/ServerFunc";
+import { addSentenceBookmark, deleteSentenceBookmark } from "../utilities/ServerFunc";
+import { TEST_USERID } from "@env";
 
 export interface Message {
     id: number;
@@ -19,7 +20,6 @@ export interface Message {
 interface ChatBubbleProps {
   index: number;
   item: Message;
-  chapterId: number;
   isBookmarked: boolean;
   inputRef?: React.RefObject<TextInput>;
   input?: string;
@@ -33,6 +33,8 @@ interface ChatBubbleProps {
   onIsClickSpeakChange?: (isSpeaking: boolean) => void;
 }
 
+const userId = TEST_USERID;
+
 export default function ChatBubble({ index, item, isBookmarked, isSpeaking, speakingList, onIsClickSpeakChange }: ChatBubbleProps) {
   useEffect(() => {
     setIsBookmark(isBookmarked);
@@ -41,7 +43,12 @@ export default function ChatBubble({ index, item, isBookmarked, isSpeaking, spea
   const [isBookmark, setIsBookmark] = useState(false);
   const [isShowTranslation, setIsShowTranslation] = useState(false);
 
-  const handleBookmark = () => {
+  const handleBookmark = async () => {
+    if (isBookmark) {
+      await deleteSentenceBookmark(item.id, userId);
+    } else {
+      const response = await addSentenceBookmark(item.id, userId);
+    }
     setIsBookmark(!isBookmark);
   }
   const handleBook = () => {
@@ -97,7 +104,14 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
   const [isBookmark, setIsBookmark] = useState(false);
   const [isShowTranslation, setIsShowTranslation] = useState(false);
 
-  const handleBookmark = () => { setIsBookmark(!isBookmark) }
+  const handleBookmark = async() => { 
+    if (isBookmark) {
+      await deleteSentenceBookmark(item.id, userId);
+    } else {
+      const response = await addSentenceBookmark(item.id, userId);
+    }
+    setIsBookmark(!isBookmark) 
+  }
   const handleBook = () => { setIsShowTranslation(!isShowTranslation) }
   const handleSpeak = () => {
     if (!(speakingList.some(value => value)) && onIsClickSpeakChange) {
@@ -173,7 +187,7 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
   );
 }
 
-export function ChatBubbleInputAll({ index, item, chapterId, isBookmarked, onEnterValue, onChagneText, inputRef, input, inputValues, isVoiceMode, isLastItem, isSpeaking, speakingList, onIsClickSpeakChange }: ChatBubbleProps) {
+export function ChatBubbleInputAll({ index, item, isBookmarked, onEnterValue, onChagneText, inputRef, input, inputValues, isVoiceMode, isLastItem, isSpeaking, speakingList, onIsClickSpeakChange }: ChatBubbleProps) {
   useEffect(() => {
     setIsBookmark(isBookmarked);
   }, [isBookmarked]);
@@ -183,9 +197,9 @@ export function ChatBubbleInputAll({ index, item, chapterId, isBookmarked, onEnt
 
   const handleBookmark = async () => {
     if (isBookmark) {
-      
+      await deleteSentenceBookmark(item.id, userId);
     } else {
-      const response = await addSentenceBookmark(chapterId, item.id);
+      const response = await addSentenceBookmark(item.id, userId);
     }
     setIsBookmark(!isBookmark);
   }

--- a/NurVo_Frontend/src/components/ChatBubble.tsx
+++ b/NurVo_Frontend/src/components/ChatBubble.tsx
@@ -2,12 +2,19 @@ import { Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from "r
 import { useEffect, useState } from "react";
 import Ionicons from 'react-native-vector-icons/Ionicons';
 
-import { Message } from "../utilities/LessonExample";
+// import { Message } from "../utilities/LessonExample";
 import { Body011, Body012, Body013, Subtext013 } from "../utilities/Fonts";
 import { layoutStyles, screenWidth } from "../utilities/Layout";
 import Colors from "../utilities/Color";
 import { speech } from "../utilities/TextToSpeech";
 
+export interface Message {
+    id: number;
+    speaker: string;
+    dialogue: string;
+    second_step?: string; 
+    korean: string;
+}
 
 interface ChatBubbleProps {
   index: number;
@@ -42,7 +49,7 @@ export default function ChatBubble({ index, item, isBookmarked, isSpeaking, spea
   const handleSpeak = () => {
     if (!(speakingList.some(value => value)) && onIsClickSpeakChange) {
       onIsClickSpeakChange(true);
-      speech(item.dialogue, item.chapter_id, item.id, item.speaker === 'Nurse', () => { onIsClickSpeakChange(false) });
+      speech(item.dialogue, item.id, item.speaker === 'Nurse', () => { onIsClickSpeakChange(false) });
     }
   }
   return (
@@ -81,7 +88,7 @@ export default function ChatBubble({ index, item, isBookmarked, isSpeaking, spea
   );
 }
 
-export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, onChagneText, inputRef, input, inputValues, isVoiceMode, isLastItem, isSpeaking, speakingList, onIsClickSpeakChange }: ChatBubbleProps) {
+export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, onChagneText, inputRef, input, inputValues, isVoiceMode, isLastItem, isSpeaking, speakingList, onIsClickSpeakChange,  }: ChatBubbleProps) {
   useEffect(() => {
     setIsBookmark(isBookmarked);
   }, [isBookmarked]);
@@ -94,13 +101,12 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
   const handleSpeak = () => {
     if (!(speakingList.some(value => value)) && onIsClickSpeakChange) {
       onIsClickSpeakChange(true);
-      speech(item.dialogue, item.chapter_id, item.id, item.speaker === 'Nurse', () => { onIsClickSpeakChange(false) });
+      speech(item.dialogue, item.id, item.speaker === 'Nurse', () => { onIsClickSpeakChange(false) });
     }
   }
 
   const textWithInputs = replaceWithInput(item.dialogue, item.second_step);
 
-  console.log("texttext", item.dialogue);
   return (
     <View key={index} style={[
       item.speaker === 'Nurse' ? bubbleStyles.messageContainerRight : bubbleStyles.messageContainerLeft
@@ -183,7 +189,7 @@ export function ChatBubbleInputAll({ index, item, isBookmarked, onEnterValue, on
   const handleSpeak = () => {
     if (!(speakingList.some(value => value)) && onIsClickSpeakChange) {
       onIsClickSpeakChange(true);
-      speech(item.dialogue, item.chapter_id, item.id, item.speaker === 'Nurse', () => { onIsClickSpeakChange(false) });
+      speech(item.second_step ? item.second_step : item.dialogue, item.id, item.speaker === 'Nurse', () => { onIsClickSpeakChange(false) });
     }
   }
 
@@ -205,11 +211,7 @@ export function ChatBubbleInputAll({ index, item, isBookmarked, onEnterValue, on
                 ref={inputRef}
                 value={input}
                 onSubmitEditing={onEnterValue}
-                onChangeText={(text) => {
-                  if (onChagneText) {
-                    onChagneText(text);
-                  }
-                }}
+                onChangeText={(text) => { if (onChagneText) { onChagneText(text); } }}
                 showSoftInputOnFocus={!isVoiceMode}
                 multiline={true}
               /> :
@@ -245,7 +247,6 @@ function replaceWithInput(text: string, textToReplace?: string) {
   if (textToReplace === '' || textToReplace === undefined) {
     return [text];
   } else {
-    console.log("Text",text);
     const segments = text.split(new RegExp(`(${textToReplace})`, 'gi'));
     const result = segments.map((segment, index) => {
       if (segment.toLowerCase() === textToReplace.toLowerCase()) {
@@ -258,11 +259,12 @@ function replaceWithInput(text: string, textToReplace?: string) {
   }
 }
 
-function checkInputWord(index: number, input: string, second_step?: string) {
+function checkInputWord(index: number, inputValue: string, second_step?: string) {
+  const jsonValue = JSON.parse(inputValue);
   return (
     <View key={index} style={[layoutStyles.VStackContainer, { paddingVertical: 10 }]}>
-      <Body011 text={input} color={Colors.NAVY} />
-      <Body013 text={`( ${second_step} )`} color={Colors.GRAY07} />
+      <Body012 text={jsonValue.text} color={Colors.GRAY07} />
+      <Body011 text={`${second_step}`} color={jsonValue.isOver ? Colors.NAVY : Colors.YELLOW} />
     </View>
   )
 }

--- a/NurVo_Frontend/src/components/ChatBubble.tsx
+++ b/NurVo_Frontend/src/components/ChatBubble.tsx
@@ -46,7 +46,7 @@ export default function ChatBubble({ index, item, isBookmarked, isSpeaking, spea
     }
   }
   return (
-    <View key={item.id} style={[
+    <View key={index} style={[
       item.speaker === 'Nurse' ? bubbleStyles.messageContainerRight : bubbleStyles.messageContainerLeft
     ]}>
       <View style={[
@@ -100,8 +100,9 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
 
   const textWithInputs = replaceWithInput(item.dialogue, item.second_step);
 
+  console.log("texttext", item.dialogue);
   return (
-    <View key={item.id} style={[
+    <View key={index} style={[
       item.speaker === 'Nurse' ? bubbleStyles.messageContainerRight : bubbleStyles.messageContainerLeft
     ]}>
       <View style={[
@@ -240,10 +241,11 @@ export function ChatBubbleInputAll({ index, item, isBookmarked, onEnterValue, on
   );
 }
 
-function replaceWithInput(text: string, textToReplace: string) {
-  if (textToReplace === '') {
+function replaceWithInput(text: string, textToReplace?: string) {
+  if (textToReplace === '' || textToReplace === undefined) {
     return [text];
   } else {
+    console.log("Text",text);
     const segments = text.split(new RegExp(`(${textToReplace})`, 'gi'));
     const result = segments.map((segment, index) => {
       if (segment.toLowerCase() === textToReplace.toLowerCase()) {
@@ -256,7 +258,7 @@ function replaceWithInput(text: string, textToReplace: string) {
   }
 }
 
-function checkInputWord(index: number, input: string, second_step: string) {
+function checkInputWord(index: number, input: string, second_step?: string) {
   return (
     <View key={index} style={[layoutStyles.VStackContainer, { paddingVertical: 10 }]}>
       <Body011 text={input} color={Colors.NAVY} />

--- a/NurVo_Frontend/src/components/ChatBubble.tsx
+++ b/NurVo_Frontend/src/components/ChatBubble.tsx
@@ -2,11 +2,11 @@ import { Platform, StyleSheet, Text, TextInput, TouchableOpacity, View } from "r
 import { useEffect, useState } from "react";
 import Ionicons from 'react-native-vector-icons/Ionicons';
 
-// import { Message } from "../utilities/LessonExample";
 import { Body011, Body012, Body013, Subtext013 } from "../utilities/Fonts";
 import { layoutStyles, screenWidth } from "../utilities/Layout";
 import Colors from "../utilities/Color";
 import { speech } from "../utilities/TextToSpeech";
+import { addSentenceBookmark } from "../utilities/ServerFunc";
 
 export interface Message {
     id: number;
@@ -19,6 +19,7 @@ export interface Message {
 interface ChatBubbleProps {
   index: number;
   item: Message;
+  chapterId: number;
   isBookmarked: boolean;
   inputRef?: React.RefObject<TextInput>;
   input?: string;
@@ -172,7 +173,7 @@ export function ChatBubbleInputWord({ index, item, isBookmarked, onEnterValue, o
   );
 }
 
-export function ChatBubbleInputAll({ index, item, isBookmarked, onEnterValue, onChagneText, inputRef, input, inputValues, isVoiceMode, isLastItem, isSpeaking, speakingList, onIsClickSpeakChange }: ChatBubbleProps) {
+export function ChatBubbleInputAll({ index, item, chapterId, isBookmarked, onEnterValue, onChagneText, inputRef, input, inputValues, isVoiceMode, isLastItem, isSpeaking, speakingList, onIsClickSpeakChange }: ChatBubbleProps) {
   useEffect(() => {
     setIsBookmark(isBookmarked);
   }, [isBookmarked]);
@@ -180,7 +181,12 @@ export function ChatBubbleInputAll({ index, item, isBookmarked, onEnterValue, on
   const [isBookmark, setIsBookmark] = useState(false);
   const [isShowTranslation, setIsShowTranslation] = useState(false);
 
-  const handleBookmark = () => {
+  const handleBookmark = async () => {
+    if (isBookmark) {
+      
+    } else {
+      const response = await addSentenceBookmark(chapterId, item.id);
+    }
     setIsBookmark(!isBookmark);
   }
   const handleBook = () => {

--- a/NurVo_Frontend/src/components/ListCellComp.tsx
+++ b/NurVo_Frontend/src/components/ListCellComp.tsx
@@ -29,6 +29,7 @@ export function ListCell({ item, checked, style }: ListCellProps) {
         <TouchableOpacity style={[listStyles.listCell, style]} onPress={() => {
             // navigation.navigate('LessonFirstScreen', {chapterId: item.chapterId});
             navigation.navigate('LessonSecondScreen', {chapterId: item.chapterId});
+            // navigation.navigate('LessonThirdScreen', {chapterId: item.chapterId});
         }}>
             <View style={[layoutStyles.VStackContainer, style, { paddingHorizontal: 20, paddingVertical: 12, marginTop: 28 }]}>
                 <Subtitle011 text={item.title} color={Colors.GRAY03} numberOfLines={1} ellipsizeMode={'tail'} />

--- a/NurVo_Frontend/src/components/ListCellComp.tsx
+++ b/NurVo_Frontend/src/components/ListCellComp.tsx
@@ -8,7 +8,7 @@ import { useNavigation } from '@react-navigation/native';
 
 import Colors from '../utilities/Color';
 import { Body023, Subtitle011 } from '../utilities/Fonts';
-import { layoutStyles, screenWidth } from '../utilities/Layout';
+import { layoutStyles } from '../utilities/Layout';
 import { HomeScreenNavigationProp } from '../utilities/NavigationTypes';
 
 interface ListCellProps {

--- a/NurVo_Frontend/src/components/ListCellComp.tsx
+++ b/NurVo_Frontend/src/components/ListCellComp.tsx
@@ -27,8 +27,7 @@ export function ListCell({ item, checked, style }: ListCellProps) {
 
     return (
         <TouchableOpacity style={[listStyles.listCell, style]} onPress={() => {
-            // navigation.navigate('LessonFirstScreen', {chapterId: item.chapterId});
-            navigation.navigate('LessonThirdScreen', {chapterId: item.chapterId});
+            navigation.navigate('LessonFirstScreen', {chapterId: item.chapterId});
 
         }}>
             <View style={[layoutStyles.VStackContainer, style, { paddingHorizontal: 20, paddingVertical: 12, marginTop: 28 }]}>

--- a/NurVo_Frontend/src/components/ListCellComp.tsx
+++ b/NurVo_Frontend/src/components/ListCellComp.tsx
@@ -27,7 +27,9 @@ export function ListCell({ item, checked, style }: ListCellProps) {
 
     return (
         <TouchableOpacity style={[listStyles.listCell, style]} onPress={() => {
-            navigation.navigate('LessonFirstScreen', {chapterId: item.chapterId});
+            // navigation.navigate('LessonFirstScreen', {chapterId: item.chapterId});
+            navigation.navigate('LessonThirdScreen', {chapterId: item.chapterId});
+
         }}>
             <View style={[layoutStyles.VStackContainer, style, { paddingHorizontal: 20, paddingVertical: 12, marginTop: 28 }]}>
                 <Subtitle011 text={item.title} color={Colors.GRAY03} numberOfLines={1} ellipsizeMode={'tail'} />

--- a/NurVo_Frontend/src/components/ListCellComp.tsx
+++ b/NurVo_Frontend/src/components/ListCellComp.tsx
@@ -15,6 +15,7 @@ interface ListCellProps {
     item: {
         title: string;
         subtitle: string;
+        chapterId: number;
     };
     checked?: boolean;
     style: ViewStyle;
@@ -26,7 +27,8 @@ export function ListCell({ item, checked, style }: ListCellProps) {
 
     return (
         <TouchableOpacity style={[listStyles.listCell, style]} onPress={() => {
-            navigation.navigate('LessonFirstScreen');
+            // navigation.navigate('LessonFirstScreen', {chapterId: item.chapterId});
+            navigation.navigate('LessonSecondScreen', {chapterId: item.chapterId});
         }}>
             <View style={[layoutStyles.VStackContainer, style, { paddingHorizontal: 20, paddingVertical: 12, marginTop: 28 }]}>
                 <Subtitle011 text={item.title} color={Colors.GRAY03} numberOfLines={1} ellipsizeMode={'tail'} />

--- a/NurVo_Frontend/src/components/ListCellComp.tsx
+++ b/NurVo_Frontend/src/components/ListCellComp.tsx
@@ -27,9 +27,7 @@ export function ListCell({ item, checked, style }: ListCellProps) {
 
     return (
         <TouchableOpacity style={[listStyles.listCell, style]} onPress={() => {
-            // navigation.navigate('LessonFirstScreen', {chapterId: item.chapterId});
-            navigation.navigate('LessonSecondScreen', {chapterId: item.chapterId});
-            // navigation.navigate('LessonThirdScreen', {chapterId: item.chapterId});
+            navigation.navigate('LessonFirstScreen', {chapterId: item.chapterId});
         }}>
             <View style={[layoutStyles.VStackContainer, style, { paddingHorizontal: 20, paddingVertical: 12, marginTop: 28 }]}>
                 <Subtitle011 text={item.title} color={Colors.GRAY03} numberOfLines={1} ellipsizeMode={'tail'} />

--- a/NurVo_Frontend/src/pages/Bookmark.tsx
+++ b/NurVo_Frontend/src/pages/Bookmark.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
-import axios from '../api/axios';
+import axios from 'axios';
 
 import Colors from '../utilities/Color';
 import { Body011 } from '../utilities/Fonts';

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
@@ -74,7 +74,6 @@ export default function LessonFirst({ navigation, route }: LessonFirstProps) {
       setIsSpeakingByIndex(0, true);
       speech(
         allMessages[0].dialogue,
-        allMessages[0].chapter_id,
         allMessages[0].id,
         allMessages[0].speaker === 'Nurse',
         () => setIsSpeakingByIndex(0, false));    //speech함수가 끝나면 setIsSpeaking(false)로 바꿔줌
@@ -93,7 +92,6 @@ export default function LessonFirst({ navigation, route }: LessonFirstProps) {
 
         speech(
           allMessages[messages.length].dialogue,
-          allMessages[messages.length].chapter_id,
           allMessages[messages.length].id,
           allMessages[messages.length].speaker === 'Nurse',
           () => setIsSpeakingByIndex(messages.length, false));    //speech함수가 끝나면 setIsSpeaking(false)로 바꿔줌
@@ -145,7 +143,7 @@ export default function LessonFirst({ navigation, route }: LessonFirstProps) {
         <CustomAlert
           onCancle={handleCancle}
           onConfirm={handleNext}
-          content='1단계 학습을 완료했습니다. 2단계 학습을 시작하시겠습니까?'
+          content={`1단계 학습을 완료했습니다.\n2단계 학습을 시작하시겠습니까?`}
           cancleText='취소'
           confirmText='확인' />}
     </KeyboardAvoidingView>

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
@@ -132,6 +132,7 @@ export default function LessonFirst({ navigation, route }: LessonFirstProps) {
             <ChatBubble
               index={index}
               item={item}
+              chapterId={route.params.chapterId}
               isBookmarked={false}
               isSpeaking={isSpeaking[index]}
               speakingList={isSpeaking}

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
@@ -75,7 +75,7 @@ export default function LessonFirst({ navigation, route }: LessonFirstProps) {
       speech(
         allMessages[0].dialogue,
         allMessages[0].id,
-        allMessages[0].speaker === 'Nurse',
+        allMessages[0].speaker.trim().toLowerCase() === 'nurse',
         () => setIsSpeakingByIndex(0, false));    //speech함수가 끝나면 setIsSpeaking(false)로 바꿔줌
     }
   }, [allMessages]);
@@ -93,7 +93,7 @@ export default function LessonFirst({ navigation, route }: LessonFirstProps) {
         speech(
           allMessages[messages.length].dialogue,
           allMessages[messages.length].id,
-          allMessages[messages.length].speaker === 'Nurse',
+          allMessages[messages.length].speaker.trim().toLowerCase() === 'nurse',
           () => setIsSpeakingByIndex(messages.length, false));    //speech함수가 끝나면 setIsSpeaking(false)로 바꿔줌
       } else {
         dispatch({ type: 'SET_SHOW_ALERT', payload: true });

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
@@ -10,16 +10,16 @@ import {
 } from 'react-native';
 
 import Colors from '../../utilities/Color';
-// import { allMessages } from '../../utilities/LessonExample';
 import ChatBubble from '../../components/ChatBubble';
 import CustomAlert from '../../components/Alert';
 import { speech, stopSpeech } from '../../utilities/TextToSpeech';
 import { fetchChapterDialogueById } from '../../utilities/ServerFunc';
+import { LessonFirstProps } from '../../utilities/NavigationTypes';
 
 const { StatusBarManager } = NativeModules;
 LogBox.ignoreLogs(['new NativeEventEmitter']);
 
-export default function LessonFirst({ navigation, route }) {
+export default function LessonFirst({ navigation, route }: LessonFirstProps) {
   const flatListRef = useRef<FlatList>(null);
   const initialState = {
     allMessages: [],
@@ -58,11 +58,19 @@ export default function LessonFirst({ navigation, route }) {
   }, []);
 
   useEffect(() => {
-    fetchChapterDialogueById(router.params.chapterId);
+    const getData = async () => {
+      const chapterId = route.params.chapterId;
+      const data = await fetchChapterDialogueById(chapterId);
+      if (data) {
+        dispatch({ type: 'SET_ALLMESSAGES', payload: data });
+      }
+    }
+    getData();
   }, []);
 
   useEffect(() => {
-    if (allMessages.length !== 0) {
+    if (allMessages.length > 0) {
+      dispatch({ type: 'SET_MESSAGES', payload: [allMessages[0]] });
       setIsSpeakingByIndex(0, true);
       speech(
         allMessages[0].dialogue,
@@ -103,7 +111,7 @@ export default function LessonFirst({ navigation, route }) {
 
   const handleNext = () => {
     navigation.pop();
-    navigation.navigate("LessonSecondScreen");
+    navigation.navigate("LessonSecondScreen", { chapterId: route.params.chapterId });
   };
 
   const handleCancle = () => {

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
@@ -132,7 +132,6 @@ export default function LessonFirst({ navigation, route }: LessonFirstProps) {
             <ChatBubble
               index={index}
               item={item}
-              chapterId={route.params.chapterId}
               isBookmarked={false}
               isSpeaking={isSpeaking[index]}
               speakingList={isSpeaking}

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonFirst.tsx
@@ -10,27 +10,28 @@ import {
 } from 'react-native';
 
 import Colors from '../../utilities/Color';
-import { Message, allMessages } from '../../utilities/LessonExample';
+// import { allMessages } from '../../utilities/LessonExample';
 import ChatBubble from '../../components/ChatBubble';
 import CustomAlert from '../../components/Alert';
 import { speech, stopSpeech } from '../../utilities/TextToSpeech';
+import { fetchChapterDialogueById } from '../../utilities/ServerFunc';
 
 const { StatusBarManager } = NativeModules;
 LogBox.ignoreLogs(['new NativeEventEmitter']);
 
-export default function LessonFirst({ navigation }: { navigation: any }) {
+export default function LessonFirst({ navigation, route }) {
   const flatListRef = useRef<FlatList>(null);
-  // const [messages, setMessages] = useState<Message[]>([allMessages[0]]);
-  // const [showAlert, setShowAlert] = useState(false);
-  // const [isSpeaking, setIsSpeaking] = useState<boolean[]>([]);
   const initialState = {
-    messages: [allMessages[0]],
+    allMessages: [],
+    messages: [],
     showAlert: false,
     isSpeaking: [],
   };
 
   const reducer = (state: typeof initialState, action: { type: string; payload?: any }) => {
     switch (action.type) {
+      case 'SET_ALLMESSAGES':
+        return { ...state, allMessages: action.payload };
       case 'SET_MESSAGES':
         return { ...state, messages: action.payload };
       case 'SET_SHOW_ALERT':
@@ -44,6 +45,7 @@ export default function LessonFirst({ navigation }: { navigation: any }) {
 
   const [state, dispatch] = useReducer(reducer, initialState);
   const {
+    allMessages,
     messages,
     showAlert,
     isSpeaking,
@@ -56,14 +58,20 @@ export default function LessonFirst({ navigation }: { navigation: any }) {
   }, []);
 
   useEffect(() => {
-    setIsSpeakingByIndex(0, true);
-    speech(
-      allMessages[0].dialogue,
-      allMessages[0].chapter_id,
-      allMessages[0].id,
-      allMessages[0].speaker === 'Nurse',
-      () => setIsSpeakingByIndex(0, false));    //speech함수가 끝나면 setIsSpeaking(false)로 바꿔줌
+    fetchChapterDialogueById(router.params.chapterId);
   }, []);
+
+  useEffect(() => {
+    if (allMessages.length !== 0) {
+      setIsSpeakingByIndex(0, true);
+      speech(
+        allMessages[0].dialogue,
+        allMessages[0].chapter_id,
+        allMessages[0].id,
+        allMessages[0].speaker === 'Nurse',
+        () => setIsSpeakingByIndex(0, false));    //speech함수가 끝나면 setIsSpeaking(false)로 바꿔줌
+    }
+  }, [allMessages]);
 
   const handlePress = () => {
     if (isSpeaking.some((value: boolean) => value)) {

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonSecond.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonSecond.tsx
@@ -257,7 +257,6 @@ export default function LessonSecond({ navigation, route }: LessonSecondProps) {
               key={index.toString()}
               index={index}
               item={item}
-              chapterId={route.params.chapterId}
               isBookmarked={false}
               onEnterValue={handleSend}
               onChagneText={handleSetInputText}

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonSecond.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonSecond.tsx
@@ -257,6 +257,7 @@ export default function LessonSecond({ navigation, route }: LessonSecondProps) {
               key={index.toString()}
               index={index}
               item={item}
+              chapterId={route.params.chapterId}
               isBookmarked={false}
               onEnterValue={handleSend}
               onChagneText={handleSetInputText}

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonSecond.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonSecond.tsx
@@ -119,7 +119,7 @@ export default function LessonSecond({ navigation, route }: LessonSecondProps) {
 
   useEffect(() => {
     if (messages.length > 0) {
-      if (!showCheckAlert && messages[messages.length - 1].speaker === 'Nurse') {
+      if (!showCheckAlert && messages[messages.length - 1].speaker.trim().toLowerCase() === 'nurse') {
         inputRef.current?.focus();
       }
     }
@@ -166,7 +166,7 @@ export default function LessonSecond({ navigation, route }: LessonSecondProps) {
   const handlePress = async () => {
     if (!(isSpeaking.some((value: boolean) => value))) {
       if (messages.length < allMessages.length) {
-        if (messages[messages.length - 1].speaker === 'Nurse' && messages[messages.length - 1].second_step) {
+        if (messages[messages.length - 1].speaker.trim().toLowerCase() === 'nurse' && messages[messages.length - 1].second_step) {
           if (inputText.trim().length === 0) {
             inputRef.current?.focus();
             return;
@@ -179,7 +179,7 @@ export default function LessonSecond({ navigation, route }: LessonSecondProps) {
           setTimeout(() => flatListRef.current?.scrollToEnd({ animated: true }), 100);
         }
       } else {
-        if (messages[messages.length - 1].speaker === 'Nurse' && messages[messages.length - 1].second_step) {
+        if (messages[messages.length - 1].speaker.trim().toLowerCase() === 'nurse' && messages[messages.length - 1].second_step) {
           await calculateCorrectPercent();
           dispatch({ type: 'SET_SHOW_CHECK_ALERT', payload: true });
         }
@@ -227,7 +227,7 @@ export default function LessonSecond({ navigation, route }: LessonSecondProps) {
     dispatch({ type: 'SET_SHOW_CHECK_ALERT', payload: false });
   };
 
-  const hasInputText = messages.length > 0 ? messages[messages.length - 1].speaker === 'Nurse' &&
+  const hasInputText = messages.length > 0 ? messages[messages.length - 1].speaker.trim().toLowerCase() === 'nurse' &&
     messages[messages.length - 1].second_step : false;
 
   // 하단 키보드 버튼 애니메이션

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonThird.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonThird.tsx
@@ -21,7 +21,7 @@ import { calculateThirdStepAccuracyWithSentenceId, fetchChapterDialogueThirdStep
 
 const { StatusBarManager } = NativeModules;
 
-export default function LessonSecond({ navigation, route }: LessonThirdProps) {
+export default function LessonThird({ navigation, route }: LessonThirdProps) {
 
   const flatListRef = useRef<FlatList>(null);
   const inputRef = useRef<TextInput>(null);

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonThird.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonThird.tsx
@@ -119,7 +119,7 @@ export default function LessonSecond({ navigation, route }: LessonThirdProps) {
 
   useEffect(() => {
     if (messages.length > 0) {
-      if (!showCheckAlert && messages[messages.length - 1].speaker === 'Nurse') {
+      if (!showCheckAlert && messages[messages.length - 1].speaker.trim().toLowerCase() === 'nurse') {
         inputRef.current?.focus();
       }
     }
@@ -166,7 +166,7 @@ export default function LessonSecond({ navigation, route }: LessonThirdProps) {
   const handlePress = async () => {
     if (!(isSpeaking.some((value: boolean) => value))) {
       if (messages.length < allMessages.length) {
-        if (messages[messages.length - 1].speaker === 'Nurse' && messages[messages.length - 1].second_step) {
+        if (messages[messages.length - 1].speaker.trim().toLowerCase() === 'nurse' && messages[messages.length - 1].second_step) {
           if (inputText.trim().length === 0) {
             inputRef.current?.focus();
             return;
@@ -179,7 +179,7 @@ export default function LessonSecond({ navigation, route }: LessonThirdProps) {
           setTimeout(() => flatListRef.current?.scrollToEnd({ animated: true }), 100);
         }
       } else {
-        if (messages[messages.length - 1].speaker === 'Nurse' && messages[messages.length - 1].second_step) {
+        if (messages[messages.length - 1].speaker.trim().toLowerCase() === 'nurse' && messages[messages.length - 1].second_step) {
           await calculateCorrectPercent();
           dispatch({ type: 'SET_SHOW_CHECK_ALERT', payload: true });
         }
@@ -225,7 +225,7 @@ export default function LessonSecond({ navigation, route }: LessonThirdProps) {
     dispatch({ type: 'SET_SHOW_CHECK_ALERT', payload: false });
   };
 
-  const hasInputText = messages.length > 0 ? messages[messages.length - 1].speaker === 'Nurse' &&
+  const hasInputText = messages.length > 0 ? messages[messages.length - 1].speaker.trim().toLowerCase() === 'nurse' &&
     messages[messages.length - 1].second_step : false;
 
   const [buttonTranslateY] = useState(new Animated.Value(140));

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonThird.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonThird.tsx
@@ -253,6 +253,7 @@ export default function LessonSecond({ navigation, route }: LessonThirdProps) {
             <ChatBubbleInputAll
               index={index}
               item={item}
+              chapterId={route.params.chapterId}
               isBookmarked={false}
               onEnterValue={handleSend}
               onChagneText={handleSetInputText}

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonThird.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonThird.tsx
@@ -12,8 +12,7 @@ import {
 } from 'react-native';
 
 import Colors from '../../utilities/Color';
-import { Message, allMessages } from '../../utilities/LessonExample';
-import ChatBubble, { ChatBubbleInputAll } from '../../components/ChatBubble';
+import { ChatBubbleInputAll } from '../../components/ChatBubble';
 import CustomAlert from '../../components/Alert';
 import VoiceRecordButton from '../../components/VoiceFuncComp';
 import { stopSpeech } from '../../utilities/TextToSpeech';
@@ -26,19 +25,6 @@ export default function LessonSecond({ navigation, route }: LessonThirdProps) {
 
   const flatListRef = useRef<FlatList>(null);
   const inputRef = useRef<TextInput>(null);
-
-  type State = {
-    allMessages: [];
-    messages: [];
-    inputText: string;
-    inputValues: Record<string, any>;
-    correctPercent: string;
-    keyboardHeight: number;
-    showNextAlert: boolean;
-    showCheckAlert: boolean;
-    isVoiceMode: boolean;
-    isSpeaking: boolean[];
-  };
 
   const initialState = {
     allMessages: [],

--- a/NurVo_Frontend/src/pages/ChapterStudy/LessonThird.tsx
+++ b/NurVo_Frontend/src/pages/ChapterStudy/LessonThird.tsx
@@ -253,7 +253,6 @@ export default function LessonSecond({ navigation, route }: LessonThirdProps) {
             <ChatBubbleInputAll
               index={index}
               item={item}
-              chapterId={route.params.chapterId}
               isBookmarked={false}
               onEnterValue={handleSend}
               onChagneText={handleSetInputText}

--- a/NurVo_Frontend/src/pages/Home.tsx
+++ b/NurVo_Frontend/src/pages/Home.tsx
@@ -21,15 +21,18 @@ const todayLessons = [
   {
     title: 'Hospital life guidance',
     subtitle: 'location of call bell, meal times, shower times, etc.',
+    chapterId: 1,
   },
   {
     title: '1 Hospital life guidance',
     subtitle: '1 location of call bell, meal times, shower times, etc.',
+    chapterId: 2,
     checked: true,
   },
   {
     title: '2 Hospital life guidance',
     subtitle: '2 location of call bell, meal times, shower times, etc.',
+    chapterId: 3,
     checked: true,
   }
 ]

--- a/NurVo_Frontend/src/utilities/Fonts.tsx
+++ b/NurVo_Frontend/src/utilities/Fonts.tsx
@@ -72,7 +72,7 @@ export function Body024({ text, color, style, numberOfLines, ellipsizeMode }: Fo
         <Text style={[fonts.body02_4, { color: color }, style]} numberOfLines={numberOfLines} ellipsizeMode={ellipsizeMode}>{text}</Text>
     )
 }
-export function Subtext011({ text, color, numberOfLines, ellipsizeMode }: FontProps) {
+export function Subtext011({ text, color, style, numberOfLines, ellipsizeMode }: FontProps) {
     return(
         <Text style={[fonts.subtext01_1, { color: color }, style]} numberOfLines={numberOfLines} ellipsizeMode={ellipsizeMode}>{text}</Text>
     )

--- a/NurVo_Frontend/src/utilities/LessonExample.ts
+++ b/NurVo_Frontend/src/utilities/LessonExample.ts
@@ -4,7 +4,7 @@ export interface Message {
     
     speaker: string;
     dialogue: string;
-    second_step: string; 
+    second_step?: string; 
     korean: string;
 }
 

--- a/NurVo_Frontend/src/utilities/NavigationTypes.ts
+++ b/NurVo_Frontend/src/utilities/NavigationTypes.ts
@@ -1,7 +1,4 @@
 import { NativeStackNavigationProp, NativeStackScreenProps } from "@react-navigation/native-stack";
-import { DataProps } from "../pages/SelectText";
-import { RouteProp } from "@react-navigation/native";
-
 
 type HomeStackParamList = {
     HomeScreen: undefined;
@@ -14,18 +11,3 @@ export type HomeScreenNavigationProp = NativeStackNavigationProp<
     'HomeScreen'
 >;
 
-
-type LibraryStackParamList = {
-  SelectText: undefined;
-  StudyPage: { data: DataProps[] };
-};
-
-// export type StudyPageProps = NativeStackScreenProps<LibraryStackParamList, 'StudyPage'>;
-
-type StudyPageNavigationProp = NativeStackNavigationProp<LibraryStackParamList, 'StudyPage'>;
-type StudyPageRouteProp = RouteProp<LibraryStackParamList, 'StudyPage'>;
-
-export type StudyPageProps = {
-  navigation: StudyPageNavigationProp;
-  route: StudyPageRouteProp;
-};

--- a/NurVo_Frontend/src/utilities/NavigationTypes.ts
+++ b/NurVo_Frontend/src/utilities/NavigationTypes.ts
@@ -1,5 +1,5 @@
 import { NativeStackNavigationProp, NativeStackScreenProps } from "@react-navigation/native-stack";
-import { RouteProp } from "@react-navigation/native";
+import { NavigationProp, ParamListBase, RouteProp } from "@react-navigation/native";
 
 export type RootStackParamList = {
   Home: undefined;
@@ -19,19 +19,6 @@ export type HomeScreenNavigationProp = NativeStackNavigationProp<
   'HomeScreen'
 >;
 
-type LessonFirstScreenNavigationProp = NativeStackNavigationProp<
-  HomeStackParamList,
-  'LessonFirstScreen'
->;
-type LessonSecondScreenNavigationProp = NativeStackNavigationProp<
-  HomeStackParamList,
-  'LessonSecondScreen'
->;
-type LessonThirdScreenNavigationProp = NativeStackNavigationProp<
-  HomeStackParamList,
-  'LessonThirdScreen'
->;
-
 type LessonFirstScreenRouteProp = RouteProp<HomeStackParamList, 'LessonFirstScreen'>;
 type LessonSecondScreenRouteProp = RouteProp<HomeStackParamList, 'LessonSecondScreen'>;
 type LessonThirdScreenRouteProp = RouteProp<HomeStackParamList, 'LessonThirdScreen'>;
@@ -42,16 +29,16 @@ export interface HomeStackScreenProps {
 }
 
 export interface LessonFirstProps {
-  navigation: LessonFirstScreenNavigationProp;
-  route: LessonFirstScreenRouteProp;
+  navigation: NavigationProp<ParamListBase>;
+  route: RouteProp<ParamListBase, 'LessonFirstScreen'>;
 }
 
 export interface LessonSecondProps {
-  navigation: LessonSecondScreenNavigationProp;
-  route: LessonSecondScreenRouteProp;
+  navigation: NavigationProp<ParamListBase>;
+  route: RouteProp<ParamListBase, 'LessonSecondScreen'>;
 }
 
 export interface LessonThirdProps {
-  navigation: LessonThirdScreenNavigationProp;
-  route: LessonThirdScreenRouteProp;
+  navigation: NavigationProp<ParamListBase>;
+  route: RouteProp<ParamListBase, 'LessonThirdScreen'>;
 }

--- a/NurVo_Frontend/src/utilities/NavigationTypes.ts
+++ b/NurVo_Frontend/src/utilities/NavigationTypes.ts
@@ -1,5 +1,5 @@
 import { NativeStackNavigationProp, NativeStackScreenProps } from "@react-navigation/native-stack";
-import { NavigationProp, ParamListBase, RouteProp } from "@react-navigation/native";
+import { RouteProp } from "@react-navigation/native";
 
 export type RootStackParamList = {
   Home: undefined;
@@ -12,11 +12,26 @@ export type HomeStackParamList = {
   LessonFirstScreen: { chapterId: number };
   LessonSecondScreen: { chapterId: number };
   LessonThirdScreen: { chapterId: number };
+  MemberDetails: undefined;
+  SetUserGoal: undefined;
 }
 
 export type HomeScreenNavigationProp = NativeStackNavigationProp<
   HomeStackParamList,
   'HomeScreen'
+>;
+
+type LessonFirstScreenNavigationProp = NativeStackNavigationProp<
+  HomeStackParamList,
+  'LessonFirstScreen'
+>;
+type LessonSecondScreenNavigationProp = NativeStackNavigationProp<
+  HomeStackParamList,
+  'LessonSecondScreen'
+>;
+type LessonThirdScreenNavigationProp = NativeStackNavigationProp<
+  HomeStackParamList,
+  'LessonThirdScreen'
 >;
 
 type LessonFirstScreenRouteProp = RouteProp<HomeStackParamList, 'LessonFirstScreen'>;
@@ -29,16 +44,16 @@ export interface HomeStackScreenProps {
 }
 
 export interface LessonFirstProps {
-  navigation: NavigationProp<ParamListBase>;
-  route: RouteProp<ParamListBase, 'LessonFirstScreen'>;
+  navigation: LessonFirstScreenNavigationProp;
+  route: LessonFirstScreenRouteProp;
 }
 
 export interface LessonSecondProps {
-  navigation: NavigationProp<ParamListBase>;
-  route: RouteProp<ParamListBase, 'LessonSecondScreen'>;
+  navigation: LessonSecondScreenNavigationProp;
+  route: LessonSecondScreenRouteProp;
 }
 
 export interface LessonThirdProps {
-  navigation: NavigationProp<ParamListBase>;
-  route: RouteProp<ParamListBase, 'LessonThirdScreen'>;
+  navigation: LessonThirdScreenNavigationProp;
+  route: LessonThirdScreenRouteProp;
 }

--- a/NurVo_Frontend/src/utilities/NavigationTypes.ts
+++ b/NurVo_Frontend/src/utilities/NavigationTypes.ts
@@ -27,10 +27,14 @@ type LessonSecondScreenNavigationProp = NativeStackNavigationProp<
   HomeStackParamList,
   'LessonSecondScreen'
 >;
+type LessonThirdScreenNavigationProp = NativeStackNavigationProp<
+  HomeStackParamList,
+  'LessonThirdScreen'
+>;
 
 type LessonFirstScreenRouteProp = RouteProp<HomeStackParamList, 'LessonFirstScreen'>;
-
 type LessonSecondScreenRouteProp = RouteProp<HomeStackParamList, 'LessonSecondScreen'>;
+type LessonThirdScreenRouteProp = RouteProp<HomeStackParamList, 'LessonThirdScreen'>;
 
 export interface HomeStackScreenProps {
   navigation: NativeStackNavigationProp<HomeStackParamList, 'HomeScreen'>;
@@ -45,4 +49,9 @@ export interface LessonFirstProps {
 export interface LessonSecondProps {
   navigation: LessonSecondScreenNavigationProp;
   route: LessonSecondScreenRouteProp;
+}
+
+export interface LessonThirdProps {
+  navigation: LessonThirdScreenNavigationProp;
+  route: LessonThirdScreenRouteProp;
 }

--- a/NurVo_Frontend/src/utilities/NavigationTypes.ts
+++ b/NurVo_Frontend/src/utilities/NavigationTypes.ts
@@ -1,13 +1,48 @@
 import { NativeStackNavigationProp, NativeStackScreenProps } from "@react-navigation/native-stack";
+import { RouteProp } from "@react-navigation/native";
 
-type HomeStackParamList = {
-    HomeScreen: undefined;
-    LessonFirstScreen: undefined;
-    LessonSecondScreen: undefined;
-    LessonThirdScreen: undefined;
-  }
+export type RootStackParamList = {
+  Home: undefined;
+  Library: undefined;
+};
+
+export type HomeStackParamList = {
+  HomeScreen: undefined;
+  LessonList: undefined;
+  LessonFirstScreen: { chapterId: number };
+  LessonSecondScreen: { chapterId: number };
+  LessonThirdScreen: { chapterId: number };
+}
+
 export type HomeScreenNavigationProp = NativeStackNavigationProp<
-    HomeStackParamList,
-    'HomeScreen'
+  HomeStackParamList,
+  'HomeScreen'
 >;
 
+type LessonFirstScreenNavigationProp = NativeStackNavigationProp<
+  HomeStackParamList,
+  'LessonFirstScreen'
+>;
+type LessonSecondScreenNavigationProp = NativeStackNavigationProp<
+  HomeStackParamList,
+  'LessonSecondScreen'
+>;
+
+type LessonFirstScreenRouteProp = RouteProp<HomeStackParamList, 'LessonFirstScreen'>;
+
+type LessonSecondScreenRouteProp = RouteProp<HomeStackParamList, 'LessonSecondScreen'>;
+
+export interface HomeStackScreenProps {
+  navigation: NativeStackNavigationProp<HomeStackParamList, 'HomeScreen'>;
+  route: RouteProp<HomeStackParamList, 'HomeScreen'>;
+}
+
+export interface LessonFirstProps {
+  navigation: LessonFirstScreenNavigationProp;
+  route: LessonFirstScreenRouteProp;
+}
+
+export interface LessonSecondProps {
+  navigation: LessonSecondScreenNavigationProp;
+  route: LessonSecondScreenRouteProp;
+}

--- a/NurVo_Frontend/src/utilities/ServerFunc.ts
+++ b/NurVo_Frontend/src/utilities/ServerFunc.ts
@@ -1,0 +1,143 @@
+import axios, { AxiosError } from "axios";
+import { RN_HOST_URL } from "@env";
+
+const HOST_URL = RN_HOST_URL;
+
+export interface ResponseProps {
+    data: [];
+}
+
+//topic과 chpater 요청
+export async function fetchAllTopic(): Promise<ResponseProps | undefined> {
+    const url = `${HOST_URL}/api/dialogues`;
+    try {
+        const response = await fetch(url);
+        const responseData = await response.json();
+        console.log(responseData.data);
+        return responseData.data;
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+//아이디로 챕터에 대한 설명 요청
+export async function fetchChapterDescriptionById(chapterId: string): Promise<ResponseProps | undefined> {
+    const url = `${HOST_URL}/api/dialogues/${chapterId}`;
+    try {
+        const response = await fetch(url);
+        const responseData = await response.json();
+        console.log(responseData.data);
+        return responseData.data;
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+export async function fetchChapterDialogueById(chapterId: string): Promise<ResponseProps | undefined> {
+    const url = `${HOST_URL}/api/dialogues/1/${chapterId}`;
+    try {
+        const response = await fetch(url);
+        const responseData = await response.json();
+        console.log(responseData.data);
+        return responseData.data;
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+export async function fetchChapterDialogueSecondStepById(chapterId: string): Promise<ResponseProps | undefined> {
+    const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step2`;
+    try {
+        const response = await fetch(url);
+        const responseData = await response.json();
+        console.log(responseData.data);
+        return responseData.data;
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+export async function fetchChapterDialogueThirdStepById(chapterId: string): Promise<ResponseProps | undefined> {
+    const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step3`;
+    try {
+        const response = await fetch(url);
+        const responseData = await response.json();
+        console.log(responseData.data);
+        return responseData.data;
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+//2단계 정확도 계산(post)
+export async function calculateSecondStepAccuracyWithSentenceId(chapterId: string, sentenceId: string, reply: string): Promise<ResponseProps | undefined> {
+    const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step2?id=${sentenceId}`;
+    const data = { "reply": reply };
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'aaplication/json'
+            },
+            body: JSON.stringify(data),
+        })
+        const responseData = await response.json();
+        console.log(responseData.data);
+        return responseData.data;
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+//3단계 정확도 계산(post)
+export async function calculateThirdStepAccuracyWithSentenceId(chapterId: string, sentenceId: string, reply: string): Promise<ResponseProps | undefined> {
+    const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step3?id=${sentenceId}`;
+    const data = { "reply": reply };
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data),
+        });
+        const responseData = await response.json();
+        console.log(responseData.data);
+        return responseData.data;
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+//문장 북마크 저장
+export async function addSentenceBookmark(chapterId: string, sentenceId: string): Promise<ResponseProps | undefined> {
+    const url = `${HOST_URL}/api/dialogues/1/${chapterId}`;
+    const data = { "conversation_id": `${sentenceId}` };
+    try {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data),
+        });
+        const responseData = await response.json();
+        console.log(responseData.data);
+        return responseData.data;
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+//북마크 불러오기
+export async function fetchBookmark() {
+    const url = `${HOST_URL}/api/bookmark`;
+    try {
+        const response = await fetch(url);
+        const responseData = await response.json();
+        console.log(responseData.data);
+        return responseData.data;
+    } catch (error) {
+        console.error(error);
+    }
+}

--- a/NurVo_Frontend/src/utilities/ServerFunc.ts
+++ b/NurVo_Frontend/src/utilities/ServerFunc.ts
@@ -106,7 +106,7 @@ export async function calculateThirdStepAccuracyWithSentenceId(chapterId:number,
 }
 
 //문장 북마크 저장
-export async function addSentenceBookmark(chapterId: string, sentenceId: string): Promise<ResponseProps | undefined> {
+export async function addSentenceBookmark(chapterId: number, sentenceId: number): Promise<ResponseProps | undefined> {
     const url = `${HOST_URL}/api/dialogues/1/${chapterId}`;
     const data = { "conversation_id": `${sentenceId}` };
     try {

--- a/NurVo_Frontend/src/utilities/ServerFunc.ts
+++ b/NurVo_Frontend/src/utilities/ServerFunc.ts
@@ -4,6 +4,7 @@ import { RN_HOST_URL } from "@env";
 const HOST_URL = RN_HOST_URL;
 
 export interface ResponseProps {
+    [x: string]: any;
     data: [];
 }
 
@@ -13,8 +14,8 @@ export async function fetchAllTopic(): Promise<ResponseProps | undefined> {
     try {
         const response = await fetch(url);
         const responseData = await response.json();
-        console.log(responseData.data);
-        return responseData.data;
+        console.log(responseData);
+        return responseData;
     } catch (error) {
         console.log(error);
     }
@@ -26,44 +27,44 @@ export async function fetchChapterDescriptionById(chapterId: string): Promise<Re
     try {
         const response = await fetch(url);
         const responseData = await response.json();
-        console.log(responseData.data);
-        return responseData.data;
+        console.log("response data", responseData);
+        return responseData;
     } catch (error) {
         console.log(error);
     }
 }
 
-export async function fetchChapterDialogueById(chapterId: string): Promise<ResponseProps | undefined> {
+export async function fetchChapterDialogueById(chapterId: number): Promise<ResponseProps | undefined> {
     const url = `${HOST_URL}/api/dialogues/1/${chapterId}`;
     try {
         const response = await fetch(url);
         const responseData = await response.json();
-        console.log(responseData.data);
-        return responseData.data;
+        console.log("response data", responseData);
+        return responseData;
     } catch (error) {
         console.log(error);
     }
 }
 
-export async function fetchChapterDialogueSecondStepById(chapterId: string): Promise<ResponseProps | undefined> {
+export async function fetchChapterDialogueSecondStepById(chapterId: number): Promise<ResponseProps | undefined> {
     const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step2`;
     try {
         const response = await fetch(url);
         const responseData = await response.json();
-        console.log(responseData.data);
-        return responseData.data;
+        console.log(responseData);
+        return responseData;
     } catch (error) {
         console.log(error);
     }
 }
 
-export async function fetchChapterDialogueThirdStepById(chapterId: string): Promise<ResponseProps | undefined> {
+export async function fetchChapterDialogueThirdStepById(chapterId: number): Promise<ResponseProps | undefined> {
     const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step3`;
     try {
         const response = await fetch(url);
         const responseData = await response.json();
-        console.log(responseData.data);
-        return responseData.data;
+        console.log(responseData);
+        return responseData;
     } catch (error) {
         console.error(error);
     }
@@ -82,8 +83,8 @@ export async function calculateSecondStepAccuracyWithSentenceId(chapterId: strin
             body: JSON.stringify(data),
         })
         const responseData = await response.json();
-        console.log(responseData.data);
-        return responseData.data;
+        console.log(responseData);
+        return responseData;
     } catch (error) {
         console.error(error);
     }
@@ -102,8 +103,8 @@ export async function calculateThirdStepAccuracyWithSentenceId(chapterId: string
             body: JSON.stringify(data),
         });
         const responseData = await response.json();
-        console.log(responseData.data);
-        return responseData.data;
+        console.log(responseData);
+        return responseData;
     } catch (error) {
         console.error(error);
     }
@@ -122,8 +123,8 @@ export async function addSentenceBookmark(chapterId: string, sentenceId: string)
             body: JSON.stringify(data),
         });
         const responseData = await response.json();
-        console.log(responseData.data);
-        return responseData.data;
+        console.log(responseData);
+        return responseData;
     } catch (error) {
         console.error(error);
     }
@@ -135,8 +136,8 @@ export async function fetchBookmark() {
     try {
         const response = await fetch(url);
         const responseData = await response.json();
-        console.log(responseData.data);
-        return responseData.data;
+        console.log(responseData);
+        return responseData;
     } catch (error) {
         console.error(error);
     }

--- a/NurVo_Frontend/src/utilities/ServerFunc.ts
+++ b/NurVo_Frontend/src/utilities/ServerFunc.ts
@@ -1,7 +1,8 @@
 import axios, { AxiosError } from "axios";
-import { RN_HOST_URL } from "@env";
+import { RN_HOST_URL, TEST_TOKEN } from "@env";
 
 const HOST_URL = RN_HOST_URL;
+const TOKEN = TEST_TOKEN;
 
 export interface ResponseProps {
     [x: string]: any;
@@ -12,7 +13,12 @@ export interface ResponseProps {
 export async function fetchAllTopic(): Promise<ResponseProps | undefined> {
     const url = `${HOST_URL}/api/dialogues`;
     try {
-        const response = await fetch(url);
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + TOKEN
+            }
+        });
         const responseData = await response.json();
         console.log(responseData);
         return responseData;
@@ -25,7 +31,12 @@ export async function fetchAllTopic(): Promise<ResponseProps | undefined> {
 export async function fetchChapterDescriptionById(chapterId: string): Promise<ResponseProps | undefined> {
     const url = `${HOST_URL}/api/dialogues/${chapterId}`;
     try {
-        const response = await fetch(url);
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + TOKEN
+            }
+        });
         const responseData = await response.json();
         console.log("response data", responseData);
         return responseData;
@@ -35,9 +46,14 @@ export async function fetchChapterDescriptionById(chapterId: string): Promise<Re
 }
 
 export async function fetchChapterDialogueById(chapterId: number): Promise<ResponseProps | undefined> {
-    const url = `${HOST_URL}/api/dialogues/1/${chapterId}`;
+    const url = `${HOST_URL}/api/dialogues/${chapterId}`;
     try {
-        const response = await fetch(url);
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + TOKEN
+            }
+        });
         const responseData = await response.json();
         console.log("response data", responseData);
         return responseData;
@@ -47,9 +63,14 @@ export async function fetchChapterDialogueById(chapterId: number): Promise<Respo
 }
 
 export async function fetchChapterDialogueSecondStepById(chapterId: number): Promise<ResponseProps | undefined> {
-    const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step2`;
+    const url = `${HOST_URL}/api/dialogues/${chapterId}/step2`;
     try {
-        const response = await fetch(url);
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + TOKEN
+            }
+        });
         const responseData = await response.json();
         console.log(responseData);
         return responseData;
@@ -59,9 +80,14 @@ export async function fetchChapterDialogueSecondStepById(chapterId: number): Pro
 }
 
 export async function fetchChapterDialogueThirdStepById(chapterId: number): Promise<ResponseProps | undefined> {
-    const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step3`;
+    const url = `${HOST_URL}/api/dialogues/${chapterId}/step3`;
     try {
-        const response = await fetch(url);
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + TOKEN
+            }
+        });
         const responseData = await response.json();
         console.log(responseData);
         return responseData;
@@ -72,10 +98,11 @@ export async function fetchChapterDialogueThirdStepById(chapterId: number): Prom
 
 //2단계 정확도 계산(post)
 export async function calculateSecondStepAccuracyWithSentenceId(chapterId:number, sentenceId: string, reply: string): Promise<ResponseProps | undefined> {
-    const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step2?id=${sentenceId}`;
+    const url = `${HOST_URL}/api/dialogues/${chapterId}/step2?id=${sentenceId}`;
     const data = { "reply": reply };
+    const headers = { 'Authorization': `Bearer ${TOKEN}` };
     try {
-        const response = await axios.post<ResponseProps>(url, data);
+        const response = await axios.post<ResponseProps>(url, data, { headers });
         console.log(response.data);
         return response.data;
     } catch (error) {
@@ -89,10 +116,11 @@ export async function calculateSecondStepAccuracyWithSentenceId(chapterId:number
 } 
 //3단계 정확도 계산(post)
 export async function calculateThirdStepAccuracyWithSentenceId(chapterId:number, sentenceId: string, reply: string): Promise<ResponseProps | undefined> {
-    const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step3?id=${sentenceId}`;
+    const url = `${HOST_URL}/api/dialogues/${chapterId}/step3?id=${sentenceId}`;
     const data = { "reply": reply };
+    const headers = { 'Authorization': `Bearer ${TOKEN}` };
     try {
-        const response = await axios.post<ResponseProps>(url, data);
+        const response = await axios.post<ResponseProps>(url, data, { headers });
         console.log(response.data);
         return response.data;
     } catch (error) {
@@ -107,10 +135,11 @@ export async function calculateThirdStepAccuracyWithSentenceId(chapterId:number,
 
 //문장 북마크 저장
 export async function addSentenceBookmark(chapterId: number, sentenceId: number): Promise<ResponseProps | undefined> {
-    const url = `${HOST_URL}/api/dialogues/1/${chapterId}`;
+    const url = `${HOST_URL}/api/dialogues/${chapterId}`;
     const data = { "conversation_id": `${sentenceId}` };
+    const headers = { 'Authorization': `Bearer ${TOKEN}` };
     try {
-        const response = await axios.post<ResponseProps>(url, data);
+        const response = await axios.post<ResponseProps>(url, data, { headers });
         console.log(response.data);
         return response.data;
     } catch (error) {

--- a/NurVo_Frontend/src/utilities/ServerFunc.ts
+++ b/NurVo_Frontend/src/utilities/ServerFunc.ts
@@ -71,42 +71,37 @@ export async function fetchChapterDialogueThirdStepById(chapterId: number): Prom
 }
 
 //2단계 정확도 계산(post)
-export async function calculateSecondStepAccuracyWithSentenceId(chapterId: string, sentenceId: string, reply: string): Promise<ResponseProps | undefined> {
+export async function calculateSecondStepAccuracyWithSentenceId(chapterId:number, sentenceId: string, reply: string): Promise<ResponseProps | undefined> {
     const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step2?id=${sentenceId}`;
     const data = { "reply": reply };
     try {
-        const response = await fetch(url, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'aaplication/json'
-            },
-            body: JSON.stringify(data),
-        })
-        const responseData = await response.json();
-        console.log(responseData);
-        return responseData;
+        const response = await axios.post<ResponseProps>(url, data);
+        console.log(response.data);
+        return response.data;
     } catch (error) {
-        console.error(error);
+        if (axios.isAxiosError(error)) {
+            const axiosError = error as AxiosError;
+            console.error(axiosError.message);
+        } else {
+            console.error(error);
+        }
     }
-}
-
+} 
 //3단계 정확도 계산(post)
-export async function calculateThirdStepAccuracyWithSentenceId(chapterId: string, sentenceId: string, reply: string): Promise<ResponseProps | undefined> {
+export async function calculateThirdStepAccuracyWithSentenceId(chapterId:number, sentenceId: string, reply: string): Promise<ResponseProps | undefined> {
     const url = `${HOST_URL}/api/dialogues/1/${chapterId}/step3?id=${sentenceId}`;
     const data = { "reply": reply };
     try {
-        const response = await fetch(url, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(data),
-        });
-        const responseData = await response.json();
-        console.log(responseData);
-        return responseData;
+        const response = await axios.post<ResponseProps>(url, data);
+        console.log(response.data);
+        return response.data;
     } catch (error) {
-        console.error(error);
+        if (axios.isAxiosError(error)) {
+            const axiosError = error as AxiosError;
+            console.error(axiosError.message);
+        } else {
+            console.error(error);
+        }
     }
 }
 
@@ -115,18 +110,16 @@ export async function addSentenceBookmark(chapterId: string, sentenceId: string)
     const url = `${HOST_URL}/api/dialogues/1/${chapterId}`;
     const data = { "conversation_id": `${sentenceId}` };
     try {
-        const response = await fetch(url, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(data),
-        });
-        const responseData = await response.json();
-        console.log(responseData);
-        return responseData;
+        const response = await axios.post<ResponseProps>(url, data);
+        console.log(response.data);
+        return response.data;
     } catch (error) {
-        console.error(error);
+        if (axios.isAxiosError(error)) {
+            const axiosError = error as AxiosError;
+            console.error(axiosError.message);
+        } else {
+            console.error(error);
+        }
     }
 }
 

--- a/NurVo_Frontend/src/utilities/ServerFunc.ts
+++ b/NurVo_Frontend/src/utilities/ServerFunc.ts
@@ -134,9 +134,29 @@ export async function calculateThirdStepAccuracyWithSentenceId(chapterId:number,
 }
 
 //문장 북마크 저장
-export async function addSentenceBookmark(chapterId: number, sentenceId: number): Promise<ResponseProps | undefined> {
-    const url = `${HOST_URL}/api/dialogues/${chapterId}`;
-    const data = { "conversation_id": `${sentenceId}` };
+export async function addSentenceBookmark(sentenceId: number, userId: string): Promise<ResponseProps | undefined> {
+    const url = `${HOST_URL}/api/bookmark/`;
+    const data = { "conversation_id": `${sentenceId}`, "user_id": `${userId}`};
+    const headers = { 'Authorization': `Bearer ${TOKEN}` };
+    try {
+        const response = await axios.post<ResponseProps>(url, data, { headers });
+        console.log(response.data);
+        return response.data;
+    } catch (error) {
+        if (axios.isAxiosError(error)) {
+            const axiosError = error as AxiosError;
+            console.error(axiosError.message);
+        } else {
+            console.error(error);
+        }
+    }
+}
+
+//문장 북마크 삭제
+export async function deleteSentenceBookmark( sentenceId: number, userId: string): Promise<ResponseProps | undefined> {
+    const url = `${HOST_URL}/api/bookmark/delete`;
+    const data = { "conversation_id": [`${sentenceId}`], "user_id": `${userId}`};
+    console.log(data);
     const headers = { 'Authorization': `Bearer ${TOKEN}` };
     try {
         const response = await axios.post<ResponseProps>(url, data, { headers });

--- a/NurVo_Frontend/src/utilities/TextToSpeech.ts
+++ b/NurVo_Frontend/src/utilities/TextToSpeech.ts
@@ -53,8 +53,7 @@ export const speech = async (text: string, chapterID: number, isNurse: boolean, 
     const speech_key = SPEECH_KEY;
 
     const voice = isNurse ? 'en-US-Wavenet-H' : 'en-AU-Neural2-B'
-    const key = speech_key
-    const address = `https://texttospeech.googleapis.com/v1/text:synthesize?key=${key}`
+    const address = `https://texttospeech.googleapis.com/v1/text:synthesize?key=${speech_key}`
     const payload = createSpeechRequest(text, voice, isNurse)
     const path = `${RNFS.DocumentDirectoryPath}/voice_${chapterID}.mp3`
     try {

--- a/NurVo_Frontend/src/utilities/TextToSpeech.ts
+++ b/NurVo_Frontend/src/utilities/TextToSpeech.ts
@@ -1,7 +1,6 @@
 import { SPEECH_KEY } from "@env";
 import RNFS from 'react-native-fs';
-import Sound from "react-native-sound";
-import SOUND from 'react-native-sound';
+import Sound from 'react-native-sound';
 
 const createSpeechRequest = (text: string, voice: string, isFemale: boolean) => ({
     headers: {
@@ -33,7 +32,7 @@ const createFile = async (path: string, data: string) => {
 }
 
 export const playSound = (path: string, onDone: () => void): Sound => {
-    const speech = new SOUND(path, '', (e) => {
+    const speech = new Sound(path, '', (e) => {
         if (e) {
             console.warn('sound failed to load the sound', e)
             return null

--- a/NurVo_Frontend/src/utilities/TextToSpeech.ts
+++ b/NurVo_Frontend/src/utilities/TextToSpeech.ts
@@ -50,14 +50,14 @@ export const playSound = (path: string, onDone: () => void): Sound => {
 }
 let play: Sound | null = null;
 //speech('hello world')와 같은 형식으로 사용하면 됩니다.
-export const speech = async (text: string, unitID: number, chapterID: number, isNurse: boolean, onDone: () => void) => {
+export const speech = async (text: string, chapterID: number, isNurse: boolean, onDone: () => void) => {
     const speech_key = SPEECH_KEY;
 
     const voice = isNurse ? 'en-US-Wavenet-H' : 'en-AU-Neural2-B'
     const key = speech_key
     const address = `https://texttospeech.googleapis.com/v1/text:synthesize?key=${key}`
     const payload = createSpeechRequest(text, voice, isNurse)
-    const path = `${RNFS.DocumentDirectoryPath}/voice_${unitID}_${chapterID}.mp3`
+    const path = `${RNFS.DocumentDirectoryPath}/voice_${chapterID}.mp3`
     try {
         const response = await fetch(`${address}`, payload)
         const result = await response.json()

--- a/NurVo_Frontend/yarn.lock
+++ b/NurVo_Frontend/yarn.lock
@@ -3978,6 +3978,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
@@ -6654,7 +6659,7 @@ react-is@^18.2.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-native-animatable@1.3.3:
+react-native-animatable@^1.3.3, react-native-animatable@1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/react-native-animatable/-/react-native-animatable-1.3.3.tgz"
   integrity sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==


### PR DESCRIPTION
<!-- 제목 : [Feat] pr 내용 -->


## 관련 이슈
- closes #4 

## 구현/변경 사항
- 프론트 .env 파일 구성
    ```
     SPEECH_KEY_IOS = 
     SPEECH_KEY_ANDROID = 
     SPEECH_KEY = 

     RN_HOST_URL = 
     TEST_TOKEN = 
     TEST_USERID = 
    ```
    - 현재 토큰과 useId를 .env에서 가져와서 사용하는 형태로 구현 -> 추후 storage 연결 필요

- addBookmark / deleteBookmark 의 경우 현재의 형태가 아닌 userId를 넘긴다는 가정하에 작성됨
    - 현재 develop 상황에서 북마크 저장은 가능하지만 삭제는 불가능 아래의 형식으로 요청하는 경우 값 추가, 삭제 확인함
    ```
     { 
          "conversation_id": "" //delete의 경우 [""]
          "user_id":""
     }
    ```
- 말풍선에서 환자와 간호사를 구분하는 item.speaker의 경우 string값으로 대소문자와 앞 뒤의 띄어쓰기에 영향을 받지 않기 위해  item.speaker.trim().toLowerCase()로 변경
- 입력한 문장보다 정답 문장이 중요하다고 판단하여 말풍선 디자인 아주 약간 변경
- 입력 문장 정확도가 80% 이상인 경우 파란글씨, 미만인 경우 노란글씨로 지정

- 2단계 학습의 경우 정확도 계산에서 2단계 제거 문장이 아닌 전체 문장과 입력 문장을 비교하여 정확도가 0으로 나오는 문제 존재
- 3단계 학습에서 api 문장 반환값이 없어 에러가 나는 경우 존재 -> 원본 문장 반환 시 해결

## 스크린샷

|정확도 80이상|정확도 80미만|
|:---:|:---:|
|![스크린샷 2023-08-16 오전 2 27 59](https://github.com/CSID-DGU/2023-S-VSA-CoCo-1/assets/41153398/8709a272-b768-4da5-b3ee-cf4d17d5074c)|![스크린샷 2023-08-16 오전 2 27 10](https://github.com/CSID-DGU/2023-S-VSA-CoCo-1/assets/41153398/8577e2b5-2653-4ef4-a51c-c1c6784877bb)|
