### PR TITLE
[Feat]프론트 측과 연결하는데 있어 오류나거나 불편한 부분 수정

### DIFF
--- a/NurVo_Backend/controllers/signup.mjs
+++ b/NurVo_Backend/controllers/signup.mjs
@@ -19,12 +19,12 @@ const messageService = new coolsmsMessageService(IDENTIFY_API_KEY, IDENTIFY_API_
 let randomSixDigitNumber;
 
 router.post('/', signup);
-router.get('/:id', checkId); //겹치는 id 있나 확인하는 엔드포인트
+router.post('/id', checkId); //겹치는 id 있나 확인하는 엔드포인트
 router.post('/identify', identify); //인증번호 발송하는 엔드포인트
 
 
 async function signup(req, res) {
-  const { id, name, password, email, phone_number } = req.body;
+  const { id, name, password, email, phone_number, nickname } = req.body;
   try {
     const user = await getUser();
     for(let i=0; i<user.length; i++){ //이미 회원가입 되어있는 유저인지 확인
@@ -38,8 +38,8 @@ async function signup(req, res) {
       id: id,
       name: name,
       password: hashedPassword,
-      email: email,
-      phone_number: phone_number
+      phone_number: phone_number,
+      nickname: nickname,
     };
     await saveUser(userInfo);
     res.send({ "message": "회원가입 성공" });
@@ -50,7 +50,7 @@ async function signup(req, res) {
 };
 
 async function checkId(req, res) {
-  const { id } = req.params;
+  const { id } = req.body;
   try {
     const user = await getUser(id);
     if (user) {
@@ -85,7 +85,7 @@ async function identify(req, res) { //사용자 인증번호 발송
     }else {
     randomSixDigitNumber = generateRandomSixDigitNumber();
     const response = await messageService.sendOne(params);
-    res.send({ "Message": "발송되었습니다" });
+    res.send({ "Message": "발송되었습니다", "Number" : randomSixDigitNumber });
   }
 
   }

--- a/NurVo_Backend/db/db.mjs
+++ b/NurVo_Backend/db/db.mjs
@@ -39,7 +39,7 @@ export const getUser = async (id) => {
 export const saveUser = async (userInfo) => { //userInfo는 id, name, password, email, phone_number를 가지고 있음  
   const client = await pool.connect();
   try { //회원정보 저장
-    const user = await client.query('INSERT INTO public.user (id, name, email, phone_number, password) VALUES ($1, $2, $3, $4, $5)', [userInfo.id, userInfo.name, userInfo.phone_number, userInfo.email, userInfo.password]);
+    const user = await client.query('INSERT INTO public.user (id, name, phone_number, password, nickname) VALUES ($1, $2, $3, $4, $5)', [userInfo.id, userInfo.name, userInfo.phone_number, userInfo.password, userInfo.nickname]);
     return user.rows[0];
   } catch (err) {
     console.error(err);

--- a/NurVo_Backend/services/dialogue.mjs
+++ b/NurVo_Backend/services/dialogue.mjs
@@ -1,29 +1,36 @@
-import { getDialogues, getSentences } from "../db/db.mjs";
+import { getDialogues, getSentences, getBookmark } from "../db/db.mjs";
 
 export async function FilterDialogues(list_id) {
   const firstStep = await getDialogues(list_id);
-  const result = firstStep.map((firstStep) => {
+  const bookmark = await getBookmark();
+  const filterFirstStep = firstStep.map((firstStep) => {
+    const isBookmarked = bookmark.some((bookmark) => bookmark.conversation_id === firstStep.id);
     return {
       id: firstStep.id,
       speaker: firstStep.speaker,
       dialogue: firstStep.dialogue,
       korean: firstStep.korean,
+      bookmark: isBookmarked,
     };
   });
+  const result = FilterDialoguesById(filterFirstStep);
   return result;
 };
 
 export async function FilterNurse(list_id) {
   const secondStep = await getDialogues(list_id);
-  console.log(secondStep);
-  const result = secondStep.map((secondStep) => {
+  const bookmark = await getBookmark();
+
+  const filterSecondStep = secondStep.map((secondStep) => {
     if(secondStep.speaker === "Nurse" || secondStep.speaker === "nurse") {
+      const isBookmarked = bookmark.some((bookmark) => bookmark.conversation_id === firstStep.id);
       return {
         id: secondStep.id,
         speaker: secondStep.speaker,
         second_step: secondStep.second_step,
         dialogue: secondStep.dialogue,
         korean: secondStep.korean,
+        bookmark: isBookmarked,
       };
     } else {
       return {
@@ -35,6 +42,15 @@ export async function FilterNurse(list_id) {
     };
     }
   );
+  const result = FilterDialoguesById(filterSecondStep);
+  return result;
+};
+
+//dialogue id로 정렬
+export async function FilterDialoguesById(dialogue) {
+  const result = dialogue.sort((a, b) => {
+    return a.id - b.id;
+  });
   return result;
 };
 
@@ -77,13 +93,16 @@ export async function Accuracy(id, reply){ // 문장별 id와 reply(클라이언
 // 대화학습 3단계 클라이언트로 보낼 데이터
 export async function FilterNurse_ThirdStep(list_id) {  
   const thirdStep = await getDialogues(list_id);
-  const result = thirdStep.map((thirdStep) => {
+  const bookmark = await getBookmark();
+  const filterThirdStep = thirdStep.map((thirdStep) => {
     if(thirdStep.speaker === "Nurse" || thirdStep.speaker === "nurse") {  // speaker가 간호사일 경우 대화 비움
+      const isBookmarked = bookmark.some((bookmark) => bookmark.conversation_id === firstStep.id);
       return {
         id: thirdStep.id,
         speaker: thirdStep.speaker,
         dialogue: "",
         korean: thirdStep.korean,
+        bookmark: isBookmarked,
       };
     }
     else{   // speaker가 간호사가 아닐경우(환자) 대화내용 그대로
@@ -95,5 +114,6 @@ export async function FilterNurse_ThirdStep(list_id) {
       }
     }
   })
+  const result = FilterDialoguesById(filterThirdStep);
   return result;
 }


### PR DESCRIPTION
## 구현/변경 사항
1. id중복확인 api 수정사항 push
- 기존에 id 중복확인은 get으로 요청을 보내고 params에 id를 포함시켜 중복을 확인하는 것이였으나 post로 변경하고, id값을 body에 보내주는 형태로 바꿈

2. 대화문을 프론트측으로 보내줄 때 id 기준으로 대화가 정렬되어 프론트측에서 처리하기 편하도록 보내주도록 함